### PR TITLE
Split coverage reports from tests

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -7,11 +7,7 @@ on:
   push:
     branches:
       - main
-    branches-ignore:
-      - 'dependabot/**'
   pull_request:
-    branches:
-      - main
     branches-ignore:
       - 'dependabot/**'
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -6,8 +6,10 @@ name: Coverage
 on:
   push:
     branches: [ main ]
+    branches-ignore: [ dependabot/** ]
   pull_request:
     branches: [ main ]
+    branches-ignore: [ dependabot/** ]
 
 jobs:
   coverage:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,34 @@
+# This workflow will do a clean install of node dependencies, build the source code and run coverage analysis to upload to Codacy
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: Coverage
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  coverage:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js 10.x
+      uses: actions/setup-node@v1
+      with:
+        node-version: 10.x
+    - run: npm ci
+    - run: npm run build --if-present
+    - run: npm test
+    - run: npm run coverage
+    - name: Run codacy-coverage-reporter
+      uses: codacy/codacy-coverage-reporter-action@v1
+      with:
+        project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
+        coverage-reports: coverage/lcov.info
+    
+    env:
+      CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -5,11 +5,15 @@ name: Coverage
 
 on:
   push:
-    branches: [ main ]
-    branches-ignore: [ dependabot/** ]
+    branches:
+      - main
+    branches-ignore:
+      - 'dependabot/**'
   pull_request:
-    branches: [ main ]
-    branches-ignore: [ dependabot/** ]
+    branches:
+      - main
+    branches-ignore:
+      - 'dependabot/**'
 
 jobs:
   coverage:

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -10,7 +10,7 @@ on:
     branches: [ main ]
 
 jobs:
-  build:
+  tests:
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -27,8 +27,3 @@ jobs:
     - run: npm ci
     - run: npm run build --if-present
     - run: npm test
-    - run: npm run coverage
-    - run: bash <(curl -Ls https://coverage.codacy.com/get.sh) report -r coverage/lcov.info
-    
-    env:
-      CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}


### PR DESCRIPTION
Uploading Codacy coverage reports breaks test action due to credentials issue, despite tests are passing. We need to extract coverage reports, so we can better see test results